### PR TITLE
Build on ubuntu 14.04 if libuv-dev is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ apt-get install libtool autoconf automake cmake libncurses5-dev g++ pkg-config u
 cargo build
 ```
 
+> Note:
+> `neovim` can get the correct version of `libuv` during the build, but only if a system one is not found.
+
 ### Linux (yum)
 
 


### PR DESCRIPTION
It should be possible to pass `cmake` some variables to force the use of the bundled lib (https://github.com/neovim/neovim/search?utf8=%E2%9C%93&q=libuv) but I found no way to make `cargo` propagate them, so the easy fix is to remove the `libuv-dev` package.