### PR TITLE
Add build instructions for MacPorts users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ brew install libtool automake cmake pkg-config gettext
 cargo build
 ```
 
+### OS X (macports)
+
+```Shell
+port install gtk3 vte-2.90
+port install libtool automake cmake pkgconfig gettext
+cargo build
+```
+
 ### Windows is not supported
 
 To support Windows, we would need to get rgtk and neovim-rs to build for it. Additionally, we would need to find a replacement for all the Posix-specific functions being used in `src/ffi.rs`.


### PR DESCRIPTION
MacPorts ships a port for vte-2.90 (for backwards compat); with these instructions, current `master` builds and runs without issue.

(I tested gtk3 w/ native UI via the +quartz variant, but I assume X11 should work just fine too)