### PR TITLE
Update brew package

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cargo build
 ### OS X (homebrew)
 
 ```Shell
-brew install gtk+3 vte3.rb
+brew install gtk+3 vte3
 brew install libtool automake cmake pkg-config gettext
 cargo build
 ```


### PR DESCRIPTION
Not sure if it was a typo or it has changed but `brew` didn't have `vte3.rb` but it did have `vte3`.