### PR TITLE
Handle negative return from fork()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -549,6 +549,8 @@ fn main() {
 
     if pid > 0 { // the gui process
         gui_main(&mut pty, gui_nvim[0], nvim_gui[1], pid);
+    } else if pid < 0 {
+    	panic!("Error forking, refusing to start");
     } else { // the nvim process
         // prepare this process to be piped into the gui
         thread::sleep(time::Duration::from_millis(100));


### PR DESCRIPTION
A negative return from fork() indicates an error forking, in which case no child process is created. If this happens, crash hard.

This is a very unlikely edge case, but I've had cases where fork fails because of ulimit rules and whatnot, so may as well handle this case.